### PR TITLE
adding badge around hours

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -32,23 +32,25 @@
         "
       >
         <h5 class="resultTitle">{{ item.marker.gsx$mealsitename.$t }}</h5>
-        <div v-if="!item.oc" class="closed">{{ getClosedMessage() }}</div>
         <span class="resultAddress">
           {{ item.marker.gsx$mealsiteaddress.$t }}{{ item.marker.gsx$mealsiteaddress.$t !== '' ? ',' : '' }}
           {{ item.marker.gsx$city.$t }}
         </span>
-        <template>
-          <div class="addloc">
+        <div>
+          <span class="closed-badge" v-if="closed(item)">
+            {{ getClosedMessage() }}
+          </span>
+          <span class="hours-badge" v-if="!closed(item)">
             {{ hours(item) }}
-          </div></template
-        >
+          </span>
+        </div>
       </b-list-group-item>
     </b-list-group>
   </div>
 </template>
 
 <script>
-import { weekdaysJs, dayFilters } from '../constants'
+import { days } from '../constants'
 
 import BusinessDetails from './BusinessDetails.vue'
 
@@ -87,22 +89,23 @@ export default {
   },
   methods: {
     getClosedMessage: function () {
-      if (this.selectedDay > 6) {
-        return this.$t(`label.closed-today`)
-      }
-
-      return `${this.$t('label.closed-on')} ${this.$t(`dayofweek.${weekdaysJs[this.selectedDay].day}`)}`
+      return this.$t(`label.closed-today`)
     },
     closeDetails: function () {
       this.showResults = true
       this.location.currentBusiness = null
     },
+    closed: function (item) {
+      var todayNum = new Date().getDay()
+      var todayDay = days[todayNum]
+      if (item.marker[todayDay].$t == 0) {
+        return true
+      } else return false
+    },
     hours: function (item) {
       var today = new Date().getDay()
-      const day = dayFilters[today]
-      if (item.marker[day].$t == 0) {
-        return 'Closed today'
-      } else return item.marker[day].$t
+      var day = days[today]
+      return item.marker[day].$t
     }
   }
 }
@@ -144,8 +147,27 @@ export default {
   }
 }
 
-.addloc {
+.closed-badge {
+  display: inline-block;
+  border-radius: 100px;
+  background-color: $marker-closed;
+  border: 1px solid $gray-400;
+  color: $gray-100;
+  padding: 2px 6px;
   margin-bottom: 8px;
+  margin-right: 5px;
+  font-size: 0.7rem;
+}
+.hours-badge {
+  display: inline-block;
+  border-radius: 100px;
+  background-color: $marker-open;
+  border: 1px solid $gray-400;
+  color: $gray-100;
+  padding: 2px 6px;
+  margin-bottom: 8px;
+  margin-right: 5px;
+  font-size: 0.7rem;
 }
 .resultList {
   max-height: calc(100vh - 70px);

--- a/meal-mapper/src/constants.js
+++ b/meal-mapper/src/constants.js
@@ -34,6 +34,7 @@ export const weekdayHours = [
 export const openStreetMapAttribution = '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 
 export const dayFilters = ['mon', 'tues', 'wed', 'thr', 'fri', 'sat', 'sun'].map((attr) => `gsx$${attr}`)
+export const days = ['sun', 'mon', 'tues', 'wed', 'thr', 'fri', 'sat'].map((attr) => `gsx$${attr}`)
 export const seniorDayFilters = ['mon', 'tues', 'wed', 'thr', 'fri', 'sat', 'sun'].map((attr) => `gsx$sp${attr}`)
 
 export const booleanFilters = [


### PR DESCRIPTION
This PR adds a badge around the hours, with the color matching the color for the open and closed markers. Screenshots below show what it looks like when a site is closed and open. In addition, the code to pull the hours from the spreadsheet was off by a day, so I fixed that.

Open businesses:
<img width="1381" alt="Screen Shot 2020-06-21 at 12 21 04 AM" src="https://user-images.githubusercontent.com/43389857/85216680-8862f480-b355-11ea-92f0-2675eb8f016b.png">

Closed businesses:
<img width="1381" alt="Screen Shot 2020-06-21 at 12 21 45 AM" src="https://user-images.githubusercontent.com/43389857/85216681-8bf67b80-b355-11ea-883b-051339f725e5.png">
