### PR TITLE
Adding get directions button that links to google maps

### DIFF
--- a/meal-mapper/src/components/BusinessDetails.vue
+++ b/meal-mapper/src/components/BusinessDetails.vue
@@ -68,6 +68,9 @@
           <p class="updated" v-if="getLastUpdatedDate != 'Invalid Date'">
             {{ $t('label.details-last-updated') }}: {{ getLastUpdatedDate }}
           </p>
+          <p>
+            <icon-list-item icon="fa fa-directions" :title="'Get directions'" :link="directionsLink(business.marker)" />
+          </p>
         </div>
       </b-list-group-item>
     </b-list-group>
@@ -96,6 +99,12 @@ export default {
     getDomain: function (url) {
       var urlParts = url.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)
       return urlParts[0]
+    },
+    directionsLink: function (marker) {
+      var address = marker.gsx$mealsiteaddress.$t
+      address = address.replace(' ', '%20')
+      address = address + '%2C%20' + marker.gsx$city.$t + '%2C%20' + marker.gsx$state.$t + '%20' + marker.gsx$zip.$t
+      return 'https://www.google.com/maps/dir/?api=1&destination=' + address
     },
     businessIcon: businessIcon,
     getAddress: getAddress


### PR DESCRIPTION
This should close #34. We now have a get directions button in Business Details that opens directions in Google Maps! Screenshots below show what the button looks like, as well as what opens when it is clicked. I also tested on mobile and it opened my Google Maps app and gave directions on the app!

<img width="288" alt="Screen Shot 2020-06-22 at 6 36 16 PM" src="https://user-images.githubusercontent.com/43389857/85341925-5ec1de80-b4b7-11ea-9e42-e7c9f5133edf.png">
<img width="1201" alt="Screen Shot 2020-06-22 at 6 36 22 PM" src="https://user-images.githubusercontent.com/43389857/85341927-5ff30b80-b4b7-11ea-84b3-39dc936d8fec.png">
