### PR TITLE
moving get directions location

### DIFF
--- a/meal-mapper/src/components/BusinessDetails.vue
+++ b/meal-mapper/src/components/BusinessDetails.vue
@@ -55,6 +55,7 @@
               :title="'Facebook'"
               :link="business.marker.gsx$facebook.$t"
             />
+            <icon-list-item icon="fa fa-directions" :title="'Get directions'" :link="directionsLink(business.marker)" />
           </p>
 
           <opening-hours :business="business.marker" :title="$t('label.openinghours')"></opening-hours>
@@ -67,9 +68,6 @@
 
           <p class="updated" v-if="getLastUpdatedDate != 'Invalid Date'">
             {{ $t('label.details-last-updated') }}: {{ getLastUpdatedDate }}
-          </p>
-          <p>
-            <icon-list-item icon="fa fa-directions" :title="'Get directions'" :link="directionsLink(business.marker)" />
           </p>
         </div>
       </b-list-group-item>


### PR DESCRIPTION
Moving get directions location as discussed with @KM-Hanson: 

<img width="283" alt="Screen Shot 2020-06-22 at 11 07 57 PM" src="https://user-images.githubusercontent.com/43389857/85356600-58def400-b4dd-11ea-8bfc-c29169d4196c.png">

Let me know if this is what you were envisioning or if I should change it!