### PR TITLE
Adding share location option

### DIFF
--- a/meal-mapper/src/components/BusinessDetails.vue
+++ b/meal-mapper/src/components/BusinessDetails.vue
@@ -116,14 +116,18 @@ export default {
     },
     addressURL: function (marker) {
       var address = marker.gsx$mealsiteaddress.$t
-      address = address.replace(' ', '%20')
-      address = address + '%2C%20' + marker.gsx$city.$t + '%2C%20' + marker.gsx$state.$t + '%20' + marker.gsx$zip.$t
+      address = address.replace(/\s/g, '%20')
+      var city = marker.gsx$city.$t.replace(/\s/g, '%20')
+      var state = marker.gsx$state.$t.replace(/\s/g, '%20')
+      address = address + '%2C%20' + city + '%2C%20' + state + '%20' + marker.gsx$zip.$t
       return address
     },
     directionsLink: function (address) {
+      console.log(address)
       return 'https://www.google.com/maps/dir/?api=1&destination=' + address
     },
     shareLink: function (address) {
+      console.log(address)
       return 'https://www.google.com/maps/search/?api=1&query=' + address
     },
     copyShareLink: function () {


### PR DESCRIPTION
Adding share location option to business details, inspired by the Google Maps share option. Screenshots below show the use case:
<img width="285" alt="Screen Shot 2020-06-23 at 4 00 57 PM" src="https://user-images.githubusercontent.com/43389857/85454575-1106ae00-b56b-11ea-8d61-a497e0e9bf2e.png"> 
Click share location:
<img width="1201" alt="Screen Shot 2020-06-23 at 4 03 56 PM" src="https://user-images.githubusercontent.com/43389857/85454680-2a0f5f00-b56b-11ea-839c-b32522385c24.png">
Click copy link:
<img width="1201" alt="Screen Shot 2020-06-23 at 4 04 18 PM" src="https://user-images.githubusercontent.com/43389857/85454741-38f61180-b56b-11ea-86ad-3e7298dd4cb6.png">
Paste link in new tab (real users could text or email the link, but when link is clicked this is what they will see:)
<img width="1201" alt="Screen Shot 2020-06-23 at 4 02 52 PM" src="https://user-images.githubusercontent.com/43389857/85454824-4b704b00-b56b-11ea-898e-59fa1ba7750a.png">


