### PR TITLE
disable clustering for chapel hill theme

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -78,6 +78,7 @@ import { latLng, Icon, ExtraMarkers } from 'leaflet'
 import Vue2LeafletMarkerCluster from 'vue2-leaflet-markercluster'
 import IconListItem from './IconListItem.vue'
 import { businessIcon } from '../utilities'
+import { theme } from 'theme.config'
 
 delete Icon.Default.prototype._getIconUrl
 Icon.Default.mergeOptions({
@@ -131,7 +132,7 @@ export default {
       clusterOptions: {
         spiderfyOnMaxZoom: true,
         maxClusterRadius: 40,
-        disableClusteringAtZoom: 16
+        disableClusteringAtZoom: theme.settings.clusterZoom
       },
       showKey: false
     }

--- a/meal-mapper/src/themes/CHMeal/theme.config.js
+++ b/meal-mapper/src/themes/CHMeal/theme.config.js
@@ -4,7 +4,8 @@ export const theme = {
       lat: 35.943068,
       lng: -79.097216
     },
-    initialMapZoom: 12
+    initialMapZoom: 12,
+    clusterZoom: 12
   },
   socialMedia: [{}],
   data: {


### PR DESCRIPTION
This should close #45. Clustering is disabled for the Chapel Hill site (this is set in the theme configuration, so if we expand to other districts they will easily be able to alter this). This is what the website initially looks like now:

<img width="1214" alt="Screen Shot 2020-06-24 at 1 51 49 AM" src="https://user-images.githubusercontent.com/43389857/85506042-9d41c100-b5bd-11ea-834a-9a396506d2ef.png">
