### PR TITLE
Modified Map Key

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -391,7 +391,7 @@ div.markeropen svg path {
 
   &.show-key i {
     opacity: 1;
-    color: $marker-selected;
+    color: theme-color('danger');
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
This should close #59 . The website shows the map key when loaded. The map key is closed by a close button. Also made map key smaller for mobile.