### PR TITLE
suggest edit form now writes to spreadsheet

### DIFF
--- a/meal-mapper/src/components/EditForm.vue
+++ b/meal-mapper/src/components/EditForm.vue
@@ -45,10 +45,43 @@ export default {
     reset: function () {
       this.selected = []
     },
+    async postForm(arr) {
+      const urlbase = 'https://docs.google.com/forms/d/e/1FAIpQLSeHMzatGVcqUcFdyxJMNtaDUApJaE_-enb3yFdWXlkOc84mXA/formResponse'
+      const form_entries = [
+        'entry.1322101299',
+        'entry.963360749',
+        'entry.1587815264',
+        'entry.91941245',
+        'entry.383547902',
+        'entry.351688335',
+        'entry.729350868',
+        'entry.117758355'
+      ]
+      const query = form_entries.reduce((u, e, i) => {
+        return u + e + '=' + encodeURI(arr[i]) + '&'
+      }, '?')
+      // POST to google form
+      try {
+        await fetch(urlbase + query.slice(0, -1), {
+          method: 'post',
+          mode: 'no-cors'
+        })
+      } catch (e) {
+        alert(this.$t('suggest-edit.submission-error'))
+      }
+    },
     submitForm: function (business) {
       if (this.selected.length == 0) {
         alert(this.$tc('suggest-edit.select-checkbox'))
       } else {
+        let data = [business.marker.gsx$mealsitename.$t, business.marker.gsx$contact.$t]
+        this.options.forEach((option) => {
+          if (this.selected.includes(option.value)) {
+            data.push(1)
+          } else data.push(0)
+        })
+        data.push(this.text)
+        this.postForm(data)
         alert(this.$tc('suggest-edit.form-submitted') + business.marker.gsx$mealsitename.$t + '!')
         this.selected = []
       }

--- a/meal-mapper/src/locales/en.json
+++ b/meal-mapper/src/locales/en.json
@@ -160,7 +160,8 @@
     "reset": "Reset",
     "submit": "Submit",
     "form-submitted": "The form has been submitted. Thank you for your help updating the entry for ",
-    "select-checkbox": "Please select at least one checkbox"
+    "select-checkbox": "Please select at least one checkbox",
+    "submission-error": "There is an error with the submission"
   },
   "zoom": {
     "noresults": "No results in this area.",


### PR DESCRIPTION
Making the suggest edit form functional- the user's data is now submitted to a Google form and Google sheet in the mapsforpeople Google Drive. This should close #7.