### PR TITLE
Changing zoom amount when bar clicked

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -114,7 +114,7 @@ export default {
     centroid: { lat: Number, lng: Number }
   },
   created() {
-    eventManager.$on('zoomIn', (zoomAmount) => {
+    eventManager.$on('zoomOut', (zoomAmount) => {
       this.zoom -= zoomAmount
     })
   },

--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -145,7 +145,7 @@ export default {
       return item.marker[day].$t
     },
     setZoom: function () {
-      eventManager.$emit('zoomIn', 0.5)
+      eventManager.$emit('zoomOut', 3.0)
     }
   }
 }


### PR DESCRIPTION
This should close #73. The zoom amount has been changed to 6 times the amount that it was originally. Here's an example of what happens when you click the zoom out button from a view with just one marker:
Initial view:
<img width="1450" alt="Screen Shot 2020-06-30 at 12 17 15 PM" src="https://user-images.githubusercontent.com/43389857/86151025-3005c280-bacc-11ea-881d-f749f7e8c1e1.png">
Zoom out once:
<img width="1450" alt="Screen Shot 2020-06-30 at 12 17 18 PM" src="https://user-images.githubusercontent.com/43389857/86151048-36943a00-bacc-11ea-836a-980674cead2b.png">
Zoom out twice (now cannot zoom out more):
<img width="1450" alt="Screen Shot 2020-06-30 at 12 17 28 PM" src="https://user-images.githubusercontent.com/43389857/86151081-3f850b80-bacc-11ea-8635-a1c0b7c6164f.png">


