### PR TITLE
Zoom out on back to list when results list item clicked

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -133,6 +133,9 @@ export default {
     closeDetails: function () {
       this.showRes = true
       this.location.currentBusiness = null
+      if (!this.location.isSetByMap) {
+        eventManager.$emit('zoomOut', 3.0)
+      }
     },
     closed: function (item) {
       var todayNum = new Date().getDay()


### PR DESCRIPTION
If a results list item is clicked, the back to list button will zoom out. If a map marker is clicked, the back to list item will not change the zoom. This should close #87.