### PR TITLE
Fixing Issue #84

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -220,10 +220,10 @@ export default {
   padding: 8px 0;
   text-align: center;
   background-color: theme-color-level('secondary', 3);
-  color: theme-color('primary');
+  color: theme-color('quaternary');
   @media (prefers-color-scheme: dark) {
     background-color: theme-color-level('secondaryDark', 5);
-    color: theme-color-level('primary', 3);
+    color: theme-color-level('quaternary', 3);
   }
   @media (max-width: 768px) {
     display: none;
@@ -249,7 +249,7 @@ export default {
   color: theme-color('quaternary');
   @media (prefers-color-scheme: dark) {
     background-color: theme-color-level('secondaryDark', 5);
-    color: theme-color-level('primary', 3);
+    color: theme-color-level('quaternary', 3);
   }
   @media (max-width: 768px) {
     display: none;


### PR DESCRIPTION
I changed the font color of the zoom warning text from the primary (teal) to quaternary (red) theme color. I did install the Prettier plug-in but did not run any tests as I assumed the change was small enough that it wouldn't have caused any unforeseen errors. 

![Screen Shot 2020-07-02 at 10 46 52 a  m](https://user-images.githubusercontent.com/63649838/86373754-c0b9db00-bc51-11ea-8d66-e5ab00b6ff9b.png)

