### PR TITLE
Changing text in FAQ button to bold

### DIFF
--- a/meal-mapper/src/components/Header.vue
+++ b/meal-mapper/src/components/Header.vue
@@ -11,7 +11,7 @@
       <b-navbar-nav class="ml-auto">
         <b-nav-item right>
           <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="button" @click="$bvModal.show('faq')"
-            ><i class="fas info-plus-circle" aria-hidden="true"></i><b>Tell me about free meals</b></b-button
+            ><i class="fas info-plus-circle" aria-hidden="true"></i><b>{{ $t('faq.linktext') }}</b></b-button
           >
         </b-nav-item>
 


### PR DESCRIPTION
Bolded "tell me about free meals" to enhance display both in web and mobile mode.

@eparadise, if you have any other suggestions of how to obtain the bold while also using $t, please let me know. I tried to use <b></b> in several places within the original expression, but was not getting the desired result. 

![Screen Shot 2020-07-03 at 5 35 29 p  m](https://user-images.githubusercontent.com/63649838/86498384-a405cc00-bd53-11ea-9287-1a8f18bb4946.png)
![Screen Shot 2020-07-03 at 5 35 23 p  m](https://user-images.githubusercontent.com/63649838/86498386-a405cc00-bd53-11ea-990b-c45826232f87.png)
![Screen Shot 2020-07-03 at 5 34 28 p  m](https://user-images.githubusercontent.com/63649838/86498387-a49e6280-bd53-11ea-86a4-cb14b55e990d.png)

