### PR TITLE
Fixing issue 106

### DIFF
--- a/meal-mapper/src/components/BusinessDetails.vue
+++ b/meal-mapper/src/components/BusinessDetails.vue
@@ -154,11 +154,11 @@ export default {
 
   i {
     font-size: 3rem;
-    color: theme-color('quinary');
+    //color: theme-color('quinary');
     margin: 7px 10px 7px 0;
     float: left;
     @media (prefers-color-scheme: dark) {
-      color: theme-color-level('quinary', 5);
+      //color: theme-color-level('quinary', 5);
     }
   }
 }
@@ -185,6 +185,9 @@ export default {
   font-size: 0.8rem;
   padding: 0.375rem 1rem;
   color: theme-color('primary');
+  @media (prefers-color-scheme: dark) {
+    color: theme-color-level('primary', 2);
+  }
 }
 
 @media (max-width: 768px) {

--- a/meal-mapper/src/components/BusinessDetailsMobile.vue
+++ b/meal-mapper/src/components/BusinessDetailsMobile.vue
@@ -211,11 +211,11 @@ export default {
 
   i {
     font-size: 1.8rem;
-    color: theme-color('quinary');
+    //color: theme-color('quinary');
     margin: 7px 10px 7px 0;
     float: left;
     @media (prefers-color-scheme: dark) {
-      color: theme-color-level('quinary', 5);
+      //color: theme-color-level('quinary', 5);
     }
   }
 }
@@ -242,6 +242,9 @@ export default {
   font-size: 0.8rem;
   padding: 0.175rem 1rem;
   color: theme-color('primary');
+  @media (prefers-color-scheme: dark) {
+    color: theme-color-level('primary', 2);
+  }
 }
 
 .closed-badge {

--- a/meal-mapper/src/components/Header.vue
+++ b/meal-mapper/src/components/Header.vue
@@ -4,7 +4,7 @@
       <slot></slot>
     </b-navbar-brand>
     <form class="form-group w-25 center-content">
-      <span class="title">{{ $t('search.find') }}</span>
+      <span class="searchTitle">{{ $t('search.find') }}</span>
       <b-form-input v-model="text" type="search" @keydown.native="search" :placeholder="$t('search.address')"></b-form-input>
     </form>
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
@@ -161,7 +161,7 @@ export default {
   left: 35%;
 }
 
-.title {
+.searchTitle {
   @media (prefers-color-scheme: dark) {
     color: $gray-200;
   }

--- a/meal-mapper/src/components/IconListItem.vue
+++ b/meal-mapper/src/components/IconListItem.vue
@@ -63,6 +63,9 @@ export default {
   }
   a {
     color: theme-color('primary');
+    @media (prefers-color-scheme: dark) {
+      color: theme-color-level(primary, 2);
+    }
   }
 
   .leafletIcon {


### PR DESCRIPTION
This should close #106. Fixing the links in dark mode (pics show before and after):
<img width="294" alt="Screen Shot 2020-07-08 at 11 40 03 PM" src="https://user-images.githubusercontent.com/43389857/86994463-68646b00-c174-11ea-9463-2adb20744974.png">
<img width="292" alt="Screen Shot 2020-07-08 at 11 38 26 PM" src="https://user-images.githubusercontent.com/43389857/86994465-69959800-c174-11ea-9e72-d4f15fc17cef.png">
