### PR TITLE
adding banner color separate from primary color

### DIFF
--- a/meal-mapper/src/components/Header.vue
+++ b/meal-mapper/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-navbar toggleable="lg" type="dark" variant="primary" id="topnav">
+  <b-navbar toggleable="lg" type="dark" class="banner" id="topnav">
     <b-navbar-brand href="#">
       <slot></slot>
     </b-navbar-brand>
@@ -164,6 +164,12 @@ export default {
 .title {
   @media (prefers-color-scheme: dark) {
     color: $gray-200;
+  }
+}
+.banner {
+  background: $banner;
+  @media (prefers-color-scheme: dark) {
+    background: $banner-dark;
   }
 }
 </style>

--- a/meal-mapper/src/themes/CHMeal/SCSS/custom.scss
+++ b/meal-mapper/src/themes/CHMeal/SCSS/custom.scss
@@ -69,6 +69,9 @@ $map-key-dark: color-yiq($map-key);
 $cluster-inner: #4196f2;
 $cluster-outer: #7eb0e6;
 
+$banner: theme-color('primary');
+$banner-dark: theme-color-level('primary', 5);
+
 // Used for the location of the user
 $map-location: $blue;
 $map-location-outline: $white;


### PR DESCRIPTION
This should close #103. The navbar background color is now governed by a banner and banner-dark color set in the custom.scss file for the theme. I just set the CHMeal values of these colors to the primary and primary dark values, but our other orgs can make this a completely different color if we think that makes the most sense!