### PR TITLE
Added arrow to help with result list visual

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -50,6 +50,7 @@
           {{ item.marker.gsx$mealsiteaddress.$t }}{{ item.marker.gsx$mealsiteaddress.$t !== '' ? ',' : '' }}
           {{ item.marker.gsx$city.$t }}
         </span>
+        <i class="fa fa-chevron-right arrow"></i>
         <div>
           <span class="closed-badge" v-if="closed(item)">{{ getClosedMessage() }}</span>
           <span class="hours-badge" v-if="!closed(item)">{{ hours(item) }}</span>
@@ -191,7 +192,12 @@ export default {
     box-shadow: 0px 0px 14px 0px rgba(255, 255, 255, 0.5);
   }
 }
-
+.arrow {
+  position: absolute;
+  bottom: 35px;
+  right: 0px;
+  color: $gray-400;
+}
 .closed-badge {
   display: inline-block;
   border-radius: 100px;


### PR DESCRIPTION
Added a light gray arrow to the right sides of each result list item to help with visualization.

![Screen Shot 2020-07-20 at 12 25 53 AM](https://user-images.githubusercontent.com/63649838/87899703-fddae700-ca1f-11ea-9e7f-48e9967b5be6.png)
