### PR TITLE
Map Key Changes and Recentering Button

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -81,12 +81,12 @@
           ></l-marker>
         </v-marker-cluster>
         <!-- below -->
-        <l-control position="bottomright" class="hideMobile user-location-button">
+        <l-control position="bottomright" class="hideMobile user-location-button default-location-button">
           <a href="#" @click="setDefaultMapView" class="user-location-link">
             <i class="fas fa-home"></i>
           </a>
         </l-control>
-        <l-control position="bottomleft" class="showMobile user-location-button">
+        <l-control position="bottomleft" class="showMobile user-location-button default-location-button">
           <a href="#" @click="setDefaultMapView" class="user-location-link">
             <i class="fas fa-home"></i>
           </a>
@@ -572,11 +572,17 @@ div.markeropen svg path {
 }
 
 .user-location-button {
-  bottom: 68px !important;
-  right: 2px !important;
+  bottom: 62px !important;
+  right: 0px !important;
   @media (max-width: 768px) {
-    bottom: 82px !important;
+    bottom: 86px !important;
     left: 2px !important;
+  }
+}
+.default-location-button {
+  bottom: 62px !important;
+  @media (max-width: 768px) {
+    bottom: 88px !important;
   }
 }
 .user-location-link {


### PR DESCRIPTION
I added a button that will recenter the map to its default location as defined in `districtData.js`. I have also changed the "Map Key" header to be ~~right~~ left aligned so it looks a little better. 

However, the only change that needs to be fixed is that on mobile the CSS for the home button is a little messed up. It's too close to the [+/-] buttons for zooming. Also ideally I would want the Home and the Current Location buttons to be clustered together like the Zoom buttons, but idk, maybe it's better separated.