### PR TITLE
Got rid of "cannot zoom out anymore" when you zoom too close bug by s…

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -38,7 +38,8 @@
 
     <b-list-group ref="results" class="resultList list-group-flush" v-if="showRes" id="results-list-nav">
       <b-alert v-if="!filteredMarkers.length" show class="noresults">
-        <strong>{{ this.$t('mapPrompts.youCanNotZoomOutMore') + ' ' + 'Zoom out for more results.' }}</strong>
+        <!-- Zoom in prompt instead: <strong>{{ this.$t('mapPrompts.youCanNotZoomOutMore') + ' ' + 'Zoom out for more results.' }}</strong> -->
+        <strong>{{ this.$t('mapPrompts.zoomOut') }}</strong>
       </b-alert>
       <b-list-group-item
         action


### PR DESCRIPTION
…imply removing the prompt. Now it will just say zoom out for more results.

I have decided to simply get rid of the this because it is obvious that the map won't let you zoom in anymore. I don't think this will cause much accessibility problems because the prompt still tells you to zoom out in order to see more results.