### PR TITLE
Added label above search bar for accessibility improvement

### DIFF
--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -6,13 +6,7 @@
           <p style="font-size: 0.9rem; text-align: center; margin-bottom: 1px;">
             <label for="searchBar.searchPrompt"> Enter Location Below </label>
           </p>
-          <b-form-input
-            v-model="text"
-            type="search"
-            @keydown.native="search"
-            id="searchBar.searchPrompt"
-            :placeholder="$t('searchBar.searchPrompt')"
-          ></b-form-input>
+          <b-form-input v-model="text" type="search" @keydown.native="search" id="searchBar.searchPrompt" :placeholder="$t('searchBar.searchPrompt')"></b-form-input>
           <p style="font-size: 0.9rem; text-align: center; margin-top: 5px;">
             {{ $t('searchBar.cantFindCloseSite') }}
             <b-button class="btn btn-sm btn-block" href="/" style="font-size: 0.8rem;">{{


### PR DESCRIPTION
This is in response to a WAVE accessibility error that the search prompt lacked a label. User can now reference the label visually or via screen reader to understand the functionality of the search site/address bar. The label reads "Enter Location Below".