### PR TITLE
Added h1 tags to landing, district, and FAQ pages

### DIFF
--- a/meal-mapper/src/components/Header.vue
+++ b/meal-mapper/src/components/Header.vue
@@ -17,22 +17,31 @@
       <!-- Right aligned nav items -->
       <b-navbar-nav class="ml-auto">
         <b-nav-item right v-if="hasFaqs && !onFaqPage()">
-          <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="link" @click="generateFaqUrl()">
-            <i class="fas info-plus-circle" aria-hidden="true"></i>
-            <b>{{ $t('FAQs.hyperlinkText') }}</b>
-          </b-button>
+          <div class="heading">
+            <h1>Meal Site Locations For District</h1>
+            <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="link" @click="generateFaqUrl()">
+              <i class="fas info-plus-circle" aria-hidden="true"></i>
+              <b>{{ $t('FAQs.hyperlinkText') }}</b>
+            </b-button>
+          </div>
         </b-nav-item>
         <b-nav-item right v-if="hasFaqs && onFaqPage()">
-          <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="link" @click="generateMapUrl()">
-            <i class="fas info-plus-circle" aria-hidden="true"></i>
-            <b>{{ $t('FAQs.backToMap') }}</b>
-          </b-button>
+          <div class="heading">
+            <h1>FAQ Page</h1>
+            <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="link" @click="generateMapUrl()">
+              <i class="fas info-plus-circle" aria-hidden="true"></i>
+              <b>{{ $t('FAQs.backToMap') }}</b>
+            </b-button>
+          </div>
         </b-nav-item>
         <b-nav-item right v-if="districtAbbr == 'mff'" href="https://meals4families.community/" target="_blank">
-          <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="button">
-            <i class="fas info-plus-circle" aria-hidden="true"></i>
-            <b>{{ $t('landingPage.aboutUs') }}</b>
-          </b-button>
+          <div class="heading">
+            <h1>Meals For Families Home Page</h1>
+            <b-button size="sm" class="my-2 my-sm-0" variant="buttons" type="button">
+              <i class="fas info-plus-circle" aria-hidden="true"></i>
+              <b>{{ $t('landingPage.aboutUs') }}</b>
+            </b-button>
+          </div>
         </b-nav-item>
 
         <!--
@@ -216,6 +225,10 @@ export default {
 .nav-item {
   margin: auto 0;
   text-align: right;
+}
+
+.heading > h1 {
+  display: none;
 }
 
 .navbar-nav > li > .dropdown-menu {


### PR DESCRIPTION
Added the following h1 tags (fixes WAVE error):

- landing page: "Meals For Families Home Page"
- map page: "Meal Site Locations For District"
- FAQ page: "FAQ Page"

***these will not be visible on the site but will be read by screen readers