### PR TITLE
Band-aid fix to improve refresh behavior when trying to resize the screen

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -192,7 +192,8 @@ export default {
         maxClusterRadius: 40,
         disableClusteringAtZoom: districtData.settings.clusterZoom
       },
-      showKey: true
+      showKey: true,
+      wasMobile: false
     }
   },
   mounted() {
@@ -200,6 +201,7 @@ export default {
     this.$nextTick(() => {
       this.$emit('bounds', this.$refs.covidMap.mapObject.getBounds())
     })
+    this.wasMobile = window.matchMedia('(max-width: 768px)').matches
   },
   computed: {
     mapKey() {
@@ -309,7 +311,12 @@ export default {
       map.setView(districtData.settings.initialMapCenter, districtData.settings.initialMapZoom)
     },
     handleResize() {
-      location.reload()
+      const isMobile = window.matchMedia('(max-width: 768px)').matches
+      if (this.wasMobile != isMobile) {
+        console.log(this.wasMobile, isMobile)
+        this.wasMobile = !isMobile
+        location.reload()
+      }
     },
     editZoomControl() {
       const zoomControl = this.$el.querySelector('.leaflet-top.leaflet-left')


### PR DESCRIPTION
Now it will only refreshes when changing from desktop to mobile widths and vice-versa. This solves the bug where on Android, if you try to type your location in the search bar, it will refresh the page, thus preventing you from typing your location. This should also improve performance when you are resizing windows from a desktop. 

However, your content is still cleared when switching from desktop to mobile and vice-versa. Thus this can be annoying when tags are eventually added and you accidently move your screen.

The reason that the original developers implemented this auto-refresh mechanism was because the Leaflet Map's zoom controls would not move to the correct side of the screen when switching. I have attempted to implement logic that would move the zoom controls and it worked somewhat well except that the order of the other controls would get out-of-order once the screen changes size in the slightest. Leaflet-Vue's API is pretty annoying at allowing users to get into the actual HTML that makes up their library.

If you want to try to reimplement my discarded logic, you have to use this function:  
`map.zoomControl.setPosition('topright');`  
where `map` is a the Leaflet map object.