### PR TITLE
Changed map key icon

### DIFF
--- a/meal-mapper/src/components/ResourceMap.vue
+++ b/meal-mapper/src/components/ResourceMap.vue
@@ -21,7 +21,7 @@
               <i @click="showKey = !showKey" class="fas fa-map-marked-alt" v-if="!showKey" />
               <i @click="showKey = !showKey" class="fas fa-times-circle" v-if="showKey" />
             </div>
-            <div class="keys" :class="{ 'show-key': showKey }" v-for="item in mapKey" v-bind:key="item.title">
+            <div class="keys" :class="{ 'show-key': showKey }" v-for="item in mapKey" v-bind:key="item.title" tabindex="0">
               <icon-list-item :leaflet-icon="item.icon" :title="item.title" link />
             </div>
           </div>
@@ -33,7 +33,7 @@
               <i @click="showKey = !showKey" class="fas fa-key" v-if="!showKey" />
               <i @click="showKey = !showKey" class="fas fa-times-circle" v-if="showKey" />
             </div>
-            <div class="keys" :class="{ 'show-key': showKey }" v-for="item in mapKey" v-bind:key="item.title">
+            <div class="keys" :class="{ 'show-key': showKey }" v-for="item in mapKey" v-bind:key="item.title" tabindex="0">
               <icon-list-item :leaflet-icon="item.icon" :title="item.title" link />
             </div>
           </div>

--- a/meal-mapper/src/components/ResultsList.vue
+++ b/meal-mapper/src/components/ResultsList.vue
@@ -51,6 +51,7 @@
         variant="sideNav"
         v-for="(item, index) in filteredMarkers"
         v-bind:key="index"
+        tabindex="0"
         class="resultItem"
         :class="{
           selected: index == location.locValue,


### PR DESCRIPTION
To open the map key, the icon looked like an help/information icon and now looks like a map with a pin instead.
<img width="566" alt="before" src="https://user-images.githubusercontent.com/52941332/123447439-771f7a00-d59f-11eb-9e4e-f667cf55acb2.png">
<img width="572" alt="after" src="https://user-images.githubusercontent.com/52941332/123447452-7c7cc480-d59f-11eb-8c2b-05fe92ba27b6.png">
